### PR TITLE
fixed TypeError in on_message_edit

### DIFF
--- a/cogs/logs.py
+++ b/cogs/logs.py
@@ -32,6 +32,9 @@ class Logs(commands.Cog):
 
 	@commands.Cog.listener()
 	async def on_message_edit(self, before, after):
+		if before.content == after.content:
+			return
+		
 		if after.guild.id != 574267523869179904:
 			return 
 		channel = self.bot.get_channel(int(self.bot.config[str(before.guild.id)]["logs_channel"]))


### PR DESCRIPTION
When an embed gets loaded, discord sends out the message edited event, and because of that it gets weird. so you just check if the content of the message actually changed, and that should fix it.